### PR TITLE
bug #37: rollback previous change

### DIFF
--- a/src/gst_signalling/utils.py
+++ b/src/gst_signalling/utils.py
@@ -34,7 +34,8 @@ def get_producer_list(host: str, port: int) -> Dict[str, Dict[str, str]]:
 
         return producers
 
-    return asyncio.run(get_list())
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(get_list())
 
 
 def find_producer_peer_id_by_name(host: str, port: int, name: str) -> str:


### PR DESCRIPTION
This change https://github.com/pollen-robotics/gst-signalling-py/pull/35 actually breaks the use of  `find_producer_peer_id_by_name` function here https://github.com/pollen-robotics/ros2_pollen_toolbox/blob/main/debug_tools/snoopdog_webrtc.py

going back to previous version